### PR TITLE
Update build, fix warnings, whitespace

### DIFF
--- a/docs/Platform.md
+++ b/docs/Platform.md
@@ -21,9 +21,9 @@ newtype Os
 
 ##### Instances
 ``` purescript
-instance isForeignOs :: IsForeign Os
-instance showOs :: Show Os
-instance eqOs :: Eq Os
+IsForeign Os
+Show Os
+Eq Os
 ```
 
 #### `runOs`
@@ -42,9 +42,9 @@ data Prerelease
 
 ##### Instances
 ``` purescript
-instance showPrerelease :: Show Prerelease
-instance eqPrerelease :: Eq Prerelease
-instance isForeignPrerelease :: IsForeign Prerelease
+Show Prerelease
+Eq Prerelease
+IsForeign Prerelease
 ```
 
 #### `PlatformRec`
@@ -62,8 +62,8 @@ newtype Platform
 
 ##### Instances
 ``` purescript
-instance showPlatform :: Show Platform
-instance isForeignPlatform :: IsForeign Platform
+Show Platform
+IsForeign Platform
 ```
 
 #### `runPlatform`

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "devDependencies": {
     "gulp": "^3.9.0",
-    "gulp-purescript": "^0.7.0",
-    "purescript": "^0.7.4",
+    "gulp-purescript": "^0.8.0",
+    "purescript": "^0.7.6",
     "webpack-stream": "^2.1.0"
   },
   "dependencies": {

--- a/src/Platform.purs
+++ b/src/Platform.purs
@@ -33,23 +33,23 @@ instance isForeignOs :: IsForeign Os where
   read f = do
     r <- { architecture: _
          , family: _
-         , version: _} 
+         , version: _}
          <$> readMaybeNull "architecture" f
-         <*> readMaybeNull "family" f 
+         <*> readMaybeNull "family" f
          <*> readMaybeNull "version" f
     pure $ Os r
 
 instance showOs :: Show Os where
   show (Os r) = "(Os \n"
-                <> "{ architecture = " <> show r.architecture <> ",\n" 
-                <> "  family = " <> show r.family <> ",\n" 
+                <> "{ architecture = " <> show r.architecture <> ",\n"
+                <> "  family = " <> show r.family <> ",\n"
                 <> "  version = " <> show r.version <> "})"
 
 instance eqOs :: Eq Os where
   eq (Os r1) (Os r2) = r1.architecture == r2.architecture
                        && r1.family == r2.family
-                       && r1.version == r2.version 
-    
+                       && r1.version == r2.version
+
 data Prerelease = Alpha | Beta
 
 instance showPrerelease :: Show Prerelease where
@@ -59,7 +59,7 @@ instance showPrerelease :: Show Prerelease where
 instance eqPrerelease :: Eq Prerelease where
   eq Alpha Alpha = true
   eq Beta Beta = true
-  eq _ _  = false 
+  eq _ _  = false
 
 instance isForeignPrerelease :: IsForeign Prerelease where
   read f = do
@@ -78,7 +78,7 @@ type PlatformRec = { description :: Maybe String
                    , ua :: Maybe String
                    , version :: Maybe String
                    , os :: Os
-                   } 
+                   }
 newtype Platform = Platform PlatformRec
 runPlatform :: Platform -> PlatformRec
 runPlatform (Platform r) = r
@@ -123,9 +123,9 @@ readMaybeNull key f = map runNull $ readProp key f
 
 foreign import getPlatform_ :: forall e. Eff (platform :: PLATFORM|e) Foreign
 
-getPlatform :: forall m e. (Monad m, MonadEff (platform :: PLATFORM|e) m) => 
-               m (Maybe Platform) 
-getPlatform = do 
+getPlatform :: forall m e. (Monad m, MonadEff (platform :: PLATFORM|e) m) =>
+               m (Maybe Platform)
+getPlatform = do
   f <- liftEff getPlatform_
   pure case read f of
     Left _ -> Nothing

--- a/src/Platform.purs
+++ b/src/Platform.purs
@@ -21,34 +21,40 @@ import Data.Foreign.Null (runNull)
 import Data.Maybe (Maybe(..))
 
 foreign import data PLATFORM :: !
-type OsRec =  { architecture :: Maybe Int
-              , family :: Maybe String
-              , version :: Maybe String
-              }
+
+type OsRec =
+  { architecture :: Maybe Int
+  , family :: Maybe String
+  , version :: Maybe String
+  }
+
 newtype Os = Os OsRec
 runOs :: Os -> OsRec
 runOs (Os r) = r
 
 instance isForeignOs :: IsForeign Os where
   read f = do
-    r <- { architecture: _
-         , family: _
-         , version: _}
-         <$> readMaybeNull "architecture" f
-         <*> readMaybeNull "family" f
-         <*> readMaybeNull "version" f
+    r <-
+      { architecture: _
+      , family: _
+      , version: _
+      } <$> readMaybeNull "architecture" f
+        <*> readMaybeNull "family" f
+        <*> readMaybeNull "version" f
     pure $ Os r
 
 instance showOs :: Show Os where
-  show (Os r) = "(Os \n"
-                <> "{ architecture = " <> show r.architecture <> ",\n"
-                <> "  family = " <> show r.family <> ",\n"
-                <> "  version = " <> show r.version <> "})"
+  show (Os r) =
+    "(Os \n"
+      <> "{ architecture = " <> show r.architecture <> ",\n"
+      <> "  family = " <> show r.family <> ",\n"
+      <> "  version = " <> show r.version <> "})"
 
 instance eqOs :: Eq Os where
-  eq (Os r1) (Os r2) = r1.architecture == r2.architecture
-                       && r1.family == r2.family
-                       && r1.version == r2.version
+  eq (Os r1) (Os r2) =
+    r1.architecture == r2.architecture
+      && r1.family == r2.family
+      && r1.version == r2.version
 
 data Prerelease = Alpha | Beta
 
@@ -69,53 +75,56 @@ instance isForeignPrerelease :: IsForeign Prerelease where
       "beta" -> pure Beta
       _ -> Left $ TypeMismatch "prerelease" "string"
 
-type PlatformRec = { description :: Maybe String
-                   , layout :: Maybe String
-                   , manufacturer :: Maybe String
-                   , name :: Maybe String
-                   , prerelease :: Maybe Prerelease
-                   , product :: Maybe String
-                   , ua :: Maybe String
-                   , version :: Maybe String
-                   , os :: Os
-                   }
+type PlatformRec =
+  { description :: Maybe String
+  , layout :: Maybe String
+  , manufacturer :: Maybe String
+  , name :: Maybe String
+  , prerelease :: Maybe Prerelease
+  , product :: Maybe String
+  , ua :: Maybe String
+  , version :: Maybe String
+  , os :: Os
+  }
+
 newtype Platform = Platform PlatformRec
 runPlatform :: Platform -> PlatformRec
 runPlatform (Platform r) = r
 
 instance showPlatform :: Show Platform where
-  show (Platform r) = "(Platform \n"
-                      <> " {description = " <> show r.description <> ",\n"
-                      <> "  layout = " <> show r.layout <> ",\n"
-                      <> "  manufacturer = " <> show r.manufacturer <> ",\n"
-                      <> "  name = " <> show r.name <> ",\n"
-                      <> "  prerelease = " <> show r.prerelease <> ",\n"
-                      <> "  product = " <> show r.product <> ",\n"
-                      <> "  ua = " <> show r.ua <> ",\n"
-                      <> "  version = " <> show r.version <> ",\n"
-                      <> "  os = " <> show r.os <> "})"
+  show (Platform r) =
+    "(Platform \n"
+      <> " {description = " <> show r.description <> ",\n"
+      <> "  layout = " <> show r.layout <> ",\n"
+      <> "  manufacturer = " <> show r.manufacturer <> ",\n"
+      <> "  name = " <> show r.name <> ",\n"
+      <> "  prerelease = " <> show r.prerelease <> ",\n"
+      <> "  product = " <> show r.product <> ",\n"
+      <> "  ua = " <> show r.ua <> ",\n"
+      <> "  version = " <> show r.version <> ",\n"
+      <> "  os = " <> show r.os <> "})"
 
 instance isForeignPlatform :: IsForeign Platform where
   read f = do
-    r <- { description: _
-         , layout: _
-         , manufacturer: _
-         , name: _
-         , prerelease: _
-         , product: _
-         , ua: _
-         , version: _
-         , os: _
-         }
-         <$> readMaybeNull "description" f
-         <*> readMaybeNull "layout" f
-         <*> readMaybeNull "manufacturer" f
-         <*> readMaybeNull "name" f
-         <*> readMaybeNull "prerelease" f
-         <*> readMaybeNull "product" f
-         <*> readMaybeNull "ua" f
-         <*> readMaybeNull "version" f
-         <*> readProp "os" f
+    r <-
+      { description: _
+      , layout: _
+      , manufacturer: _
+      , name: _
+      , prerelease: _
+      , product: _
+      , ua: _
+      , version: _
+      , os: _
+      } <$> readMaybeNull "description" f
+        <*> readMaybeNull "layout" f
+        <*> readMaybeNull "manufacturer" f
+        <*> readMaybeNull "name" f
+        <*> readMaybeNull "prerelease" f
+        <*> readMaybeNull "product" f
+        <*> readMaybeNull "ua" f
+        <*> readMaybeNull "version" f
+        <*> readProp "os" f
     pure $ Platform r
 
 readMaybeNull :: forall a. (IsForeign a) => String -> Foreign -> F (Maybe a)
@@ -123,8 +132,7 @@ readMaybeNull key f = map runNull $ readProp key f
 
 foreign import getPlatform_ :: forall e. Eff (platform :: PLATFORM|e) Foreign
 
-getPlatform :: forall m e. (Monad m, MonadEff (platform :: PLATFORM|e) m) =>
-               m (Maybe Platform)
+getPlatform :: forall m e. (Monad m, MonadEff (platform :: PLATFORM|e) m) => m (Maybe Platform)
 getPlatform = do
   f <- liftEff getPlatform_
   pure case read f of

--- a/src/Platform.purs
+++ b/src/Platform.purs
@@ -18,7 +18,7 @@ import Data.Either (either, Either(..))
 import Data.Foreign (readString, Foreign(), ForeignError(TypeMismatch), F())
 import Data.Foreign.Class (IsForeign, read, readProp)
 import Data.Foreign.Null (runNull)
-import Data.Maybe (Maybe(..), maybe)
+import Data.Maybe (Maybe(..))
 
 foreign import data PLATFORM :: !
 type OsRec =  { architecture :: Maybe Int


### PR DESCRIPTION
- update `purescript` and `gulp-purescript` build dependencies
- fix unused import warning
- fix trailing whitespace, impose consistent whitespace regime
